### PR TITLE
Release/v0.2.1

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -1,0 +1,42 @@
+name: build-and-push-docker-image
+
+on:
+  workflow_call:
+    inputs:
+      imageName:
+        required: true
+        type: string
+      imageTag:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+jobs:
+  docker:
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.imageName }}:${{ inputs.imageTag }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,16 @@
+name: Develop nightly build & push to Docker Hub
+
+on:
+  push: 
+    branches:
+      - develop
+
+jobs:
+  nightly-build-push:
+    uses: ./.github/workflows/build-and-push-docker-image.yml
+    with:
+      imageName: dns-manager
+      imageTag: nightly
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release build & push to Docker Hub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-build-push:
+    uses: ./.github/workflows/build-and-push-docker-image.yml
+    with:
+      imageName: dns-manager
+      imageTag: ${{ github.event.release.tag_name }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# callv2-dns-manager
+# callv2-dns-manager 
 
 ## 🌐 Environment Variables
 


### PR DESCRIPTION
This pull request introduces reusable GitHub Actions workflows for building and pushing Docker images, streamlining the CI/CD process for nightly and release builds. The changes include the creation of a reusable workflow and its integration into specific workflows for nightly and release builds.

### Creation of reusable workflow:
* [`.github/workflows/build-and-push-docker-image.yml`](diffhunk://#diff-63d86cca28be8586869affd2baf5d48489229f5d9b4684c11beb787eee6f614cR1-R42): Added a reusable workflow to build and push Docker images. It accepts `imageName` and `imageTag` as inputs and uses Docker Hub credentials for authentication.

### Integration into specific workflows:
* [`.github/workflows/nightly.yaml`](diffhunk://#diff-e79198339eb3fcc6974b6912e52526068eab3b7952ed67d03276479a235eb58eR1-R16): Configured a nightly workflow to trigger on `develop` branch pushes. It uses the reusable workflow to build and push a Docker image with the `nightly` tag.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R15): Configured a release workflow to trigger on published releases. It uses the reusable workflow to build and push a Docker image tagged with the release version.